### PR TITLE
Updated the "recurring card" update request to Realex to use card-update-card

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,5 @@ group :development do
 end
 
 group :test do
-  gem 'rspec'
+  gem 'rspec', '~> 2.6.0'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,13 +1,13 @@
 require 'rake'
-require 'spec/rake/spectask'
+require 'rspec/core/rake_task'
 
 desc 'Default: run specs.'
 task :default => :spec
 
 desc 'Run the specs'
-Spec::Rake::SpecTask.new(:spec) do |t|
-  t.spec_opts = ['--colour --format progress --loadby mtime --reverse']
-  t.spec_files = FileList['spec/**/*_spec.rb']
+RSpec::Core::RakeTask.new(:spec) do |spec|
+  spec.rspec_opts = ['--colour --format progress']
+  spec.pattern = 'spec/**/*_spec.rb'
 end
 
 PKG_FILES = FileList[
@@ -25,7 +25,7 @@ begin
     gemspec.email = "paul@rslw.com"
     gemspec.homepage = "http://github.com/paulca/realex"
     gemspec.authors = ["Paul Campbell"]
-    gemspec.version = "0.3.3"
+    gemspec.version = "0.3.4"
     gemspec.add_dependency 'nokogiri', '~> 1.4'
   end
 rescue LoadError

--- a/lib/real_ex/client.rb
+++ b/lib/real_ex/client.rb
@@ -14,7 +14,7 @@ module RealEx
       def build_xml(type, &block)
         xml = Builder::XmlMarkup.new(:indent => 2)
         xml.instruct!
-        xml.request(:timestamp => timestamp, :type => type) { |r| block.call(r) }
+        xml.request(:type => type, :timestamp => timestamp) { |r| block.call(r) }
         xml.target!
       end
     

--- a/lib/real_ex/recurring.rb
+++ b/lib/real_ex/recurring.rb
@@ -71,7 +71,7 @@ module RealEx
       attributes :card, :payer, :update, :reference
 
       def request_type
-        @request_type = update == true ? 'eft-update-expiry-date' : 'card-new'
+        @request_type = update == true ? 'card-update-card' : 'card-new'
       end
       
       def to_xml
@@ -90,7 +90,7 @@ module RealEx
       # 20030516181127.yourmerchantid.uniqueid…smithj01.John Smith.498843******9991
       def hash
         if update == true
-          RealEx::Client.build_hash([RealEx::Client.timestamp, RealEx::Config.merchant_id, payer.reference, reference,card.expiry_date])
+          RealEx::Client.build_hash([RealEx::Client.timestamp, RealEx::Config.merchant_id, payer.reference, reference, card.expiry_date, card.number])
         else
           RealEx::Client.build_hash([RealEx::Client.timestamp, RealEx::Config.merchant_id, order_id, '', '', payer.reference,card.cardholder_name,card.number])
         end

--- a/lib/real_ex/transaction.rb
+++ b/lib/real_ex/transaction.rb
@@ -5,7 +5,7 @@ module RealEx
     attr_accessor :comments
     attr_accessor :authcode, :pasref
     
-    REQUEST_TYPES = ['auth', 'manual', 'offline', 'tss', 'payer-new', 'payer-edit', 'card-new', 'eft-update-expiry-date']
+    REQUEST_TYPES = ['auth', 'manual', 'offline', 'tss', 'payer-new', 'payer-edit', 'card-new', 'card-update-card']
     
     def initialize(hash = {})
       super(hash)

--- a/realex.gemspec
+++ b/realex.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{realex}
-  s.version = "0.3.3"
+  s.version = "0.3.4"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Paul Campbell"]

--- a/spec/recurring_spec.rb
+++ b/spec/recurring_spec.rb
@@ -43,7 +43,7 @@ describe "RealEx::Recurring" do
   
   it "should create lovely XML for the card update" do
     @card.update = true
-    @card.to_xml.should == "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<request type=\"eft-update-expiry-date\" timestamp=\"20090326160218\">\n  <merchantid>paul</merchantid>\n  <orderid></orderid>\n  <account>internet</account>\n  <card>\n    <ref>billabong</ref>\n    <payerref>boom</payerref>\n    <number>4111111111111111</number>\n    <expdate>0802</expdate>\n    <chname>Paul Campbell</chname>\n    <type>VISA</type>\n  </card>\n  <sha1hash>a97a52b7e5afa2980f4298251c2b8b836fd82331</sha1hash>\n</request>\n"
+    @card.to_xml.should == "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<request type=\"card-update-card\" timestamp=\"20090326160218\">\n  <merchantid>paul</merchantid>\n  <orderid></orderid>\n  <account>internet</account>\n  <card>\n    <ref>billabong</ref>\n    <payerref>boom</payerref>\n    <number>4111111111111111</number>\n    <expdate>0802</expdate>\n    <chname>Paul Campbell</chname>\n    <type>VISA</type>\n  </card>\n  <sha1hash>cdcb4dd95d0d61d7c86685b1e465796ea55bdcea</sha1hash>\n</request>\n"
   end
   
   it "should create tasty XML for the authorization" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,9 @@
 begin
-  require 'spec'
+  require 'rspec'
 rescue LoadError
   require 'rubygems'
   gem 'rspec'
-  require 'spec'
+  require 'rspec'
 end
 
 dir = File.dirname(__FILE__)


### PR DESCRIPTION
### Changed the update recurring card Realex request type

Previously the following code would have only enabled you to update the expiry date of the card:

```
recurring_card = RealEx::Recurring::Card.new(:payer => payer, :reference => 'paulcampbell')
recurring_card.card = card
recurring_card.update = true
recurring_card.save!
```

This now uses `card-update-card` instead of `eft-update-expiry-date` to allow the whole card to be updated. According to the Realex docs, I believe this will allow you to update:
- Full card
- Cardholder name
- Expiry date
- Issue number
### Updated specs to use RSpec 2.6.x

Updated gem requirement and Rakefile to work with RSpec 2.6.0
### Updated tests to pass with changes to card update request type
