### PR TITLE
Full card number, CVV, etc shouldn't be required to cancel a recurring card

### DIFF
--- a/lib/real_ex/recurring.rb
+++ b/lib/real_ex/recurring.rb
@@ -85,10 +85,13 @@ module RealEx
           per.card do |c|
             c.ref reference
             c.payerref payer.reference
-            c.number card.number
-            c.expdate card.expiry_date
-            c.chname card.cardholder_name
-            c.type card.type
+
+            unless self.cancel
+              c.number card.number
+              c.expdate card.expiry_date
+              c.chname card.cardholder_name
+              c.type card.type
+            end
           end
         end
       end

--- a/lib/real_ex/recurring.rb
+++ b/lib/real_ex/recurring.rb
@@ -86,7 +86,7 @@ module RealEx
             c.ref reference
             c.payerref payer.reference
 
-            unless self.cancel
+            if !self.cancel
               c.number card.number
               c.expdate card.expiry_date
               c.chname card.cardholder_name


### PR DESCRIPTION
Hey Paul,

This is a great library, cheers.

In my use I'm of course not storing the card details once they've been stored in Realex, turns out there was an exception thrown when trying to cancel a card using just its order ID.

This removes the need to have the full card details to destroy! a RealEx::Recurring::Card.

Thanks
