### PR TITLE
Addition to gem to allow account overriding

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ begin
     gemspec.email = "paul@rslw.com"
     gemspec.homepage = "http://github.com/paulca/realex"
     gemspec.authors = ["Paul Campbell"]
-    gemspec.version = "0.4"
+    gemspec.version = "0.4.1"
     gemspec.add_dependency 'nokogiri', '~> 1.4'
   end
 rescue LoadError

--- a/lib/real_ex/recurring.rb
+++ b/lib/real_ex/recurring.rb
@@ -42,7 +42,7 @@ module RealEx
             payer.email address.email
             if !comments.empty?
               payer.comments do |c|
-                comments.each_with_index do |i,comment|
+                comments.each_with_index do |comment,i|
                   c.comment(comment, :id => i + 1)
                 end
               end

--- a/lib/real_ex/transaction.rb
+++ b/lib/real_ex/transaction.rb
@@ -1,7 +1,7 @@
 module RealEx
   class Transaction
     include Initializer
-    attributes :card, :amount, :order_id, :currency, :autosettle, :variable_reference, :remote_uri, :real_vault_uri
+    attributes :card, :amount, :order_id, :currency, :autosettle, :variable_reference, :remote_uri, :real_vault_uri, :account
     attr_accessor :comments
     attr_accessor :authcode, :pasref
     
@@ -14,6 +14,7 @@ module RealEx
       self.currency ||= RealEx::Config.currency || 'EUR'
       self.remote_uri ||= RealEx::Config.remote_uri || '/epage-remote.cgi'
       self.real_vault_uri ||= RealEx::Config.real_vault_uri || '/epage-remote-plugins.cgi'
+      self.account ||= RealEx::Config.account
     end
     
     def request_type
@@ -30,7 +31,7 @@ module RealEx
         r.orderid order_id
         r.authcode authcode if authcode
         r.pasref pasref if pasref
-        r.account RealEx::Config.account
+        r.account account
         if block_given?
           block.call(r)
         end

--- a/lib/real_ex/transaction.rb
+++ b/lib/real_ex/transaction.rb
@@ -37,7 +37,7 @@ module RealEx
         end
         if !comments.empty?
           r.comments do |c|
-            comments.each_with_index do |index,comment|
+            comments.each_with_index do |comment,index|
               c.comment(comment, :id => index)
             end
           end
@@ -158,7 +158,7 @@ module RealEx
         per.refundhash refund_hash
         if !comments.empty?
           per.comments do |c|
-            comments.each_with_index do |index,comment|
+            comments.each_with_index do |comment,index|
               c.comment(comment, :id => index)
             end
           end

--- a/lib/real_ex/transaction.rb
+++ b/lib/real_ex/transaction.rb
@@ -38,7 +38,7 @@ module RealEx
         if !comments.empty?
           r.comments do |c|
             comments.each_with_index do |comment,index|
-              c.comment(comment, :id => index)
+              c.comment(comment, :id => index + 1)
             end
           end
         end
@@ -159,7 +159,7 @@ module RealEx
         if !comments.empty?
           per.comments do |c|
             comments.each_with_index do |comment,index|
-              c.comment(comment, :id => index)
+              c.comment(comment, :id => index + 1)
             end
           end
         end

--- a/spec/transaction_spec.rb
+++ b/spec/transaction_spec.rb
@@ -33,6 +33,18 @@ describe "RealEx::Transaction" do
     @transaction.comments.should == ["This is a comment"]
   end
   
+  it "should allow overriding of the account" do
+    @transaction = RealEx::Authorization.new(
+                    :card         => @card,
+                    :amount       => 500,
+                    :order_id     => 1234,
+                    :currency     => 'EUR',
+                    :autosettle   => true,
+                    :account      => "override"
+                    )
+    @transaction.account.should == "override"
+  end
+  
   it "should build the xml" do
     @transaction.to_xml.should == "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<request type=\"auth\" timestamp=\"20090326160218\">\n  <merchantid>paul</merchantid>\n  <orderid>1234</orderid>\n  <account>internet</account>\n  <amount currency=\"EUR\">500</amount>\n  <card>\n    <number>4111111111111111</number>\n    <expdate>0802</expdate>\n    <chname>Paul Campbell</chname>\n    <type>VISA</type>\n  </card>\n  <autosettle flag=\"1\"/>\n  <tssinfo>\n  </tssinfo>\n  <sha1hash>d979885b0a296469d85ada0f08c5577d857142a0</sha1hash>\n</request>\n"
   end


### PR DESCRIPTION
Hi Paul,

I've made another addition to the RealEx gem - this time to allow account overriding.  Why would this be useful?  Well as we've just found out if you want to accept American Express is has to be under a different subaccount than the normal settling bank.  Therefore you need to switch accounts on a per request basis depending on whether the customer has a visa/mastercard or a amex card stored.

The change to the gem is very small thanks to the way it was originally created.  Comes with appropriate spec.

George
