### PR TITLE
Now you can add an account without an address if you like.

### DIFF
--- a/lib/real_ex/recurring.rb
+++ b/lib/real_ex/recurring.rb
@@ -1,20 +1,20 @@
 module RealEx
   module Recurring
-    
+
     class Transaction < RealEx::Transaction
       def authorize!
         RealEx::Response.new_from_xml(RealEx::Client.call(real_vault_uri, to_xml))
       end
     end
-    
+
     class Payer < Transaction
       attributes :type, :reference, :title, :firstname, :lastname, :address, :company, :comments
       attributes :update
-      
+
       def request_type
         @request_type = update == true ? 'payer-edit' : 'payer-new'
       end
-      
+
       def to_xml
         super do |per|
           per.payer(:type => type, :ref => reference) do |payer|
@@ -22,24 +22,28 @@ module RealEx
             payer.firstname firstname
             payer.surname lastname
             payer.company company
-            payer.address do |add|
-                add.line1 address.line1
-                add.line1 address.line2
-                add.line3 address.line3
-                add.city address.city
-                add.county address.county
-                add.postcode address.post_code
-                add.country(address.country, :country_code => address.country_code)
-            end
-            if address.phone_numbers.kind_of?(Hash)
-              payer.phonenumbers do |numbers|
-                numbers.home address.phone_numbers[:home]
-                numbers.work address.phone_numbers[:work]
-                numbers.fax address.phone_numbers[:fax]
-                numbers.mobile address.phone_numbers[:mobile]
+
+            unless address.nil?
+              payer.address do |add|
+                  add.line1 address.line1
+                  add.line1 address.line2
+                  add.line3 address.line3
+                  add.city address.city
+                  add.county address.county
+                  add.postcode address.post_code
+                  add.country(address.country, :country_code => address.country_code)
               end
+              if address.phone_numbers.kind_of?(Hash)
+                payer.phonenumbers do |numbers|
+                  numbers.home address.phone_numbers[:home]
+                  numbers.work address.phone_numbers[:work]
+                  numbers.fax address.phone_numbers[:fax]
+                  numbers.mobile address.phone_numbers[:mobile]
+                end
+              end
+              payer.email address.email
             end
-            payer.email address.email
+
             if !comments.empty?
               payer.comments do |c|
                 comments.each_with_index do |i,comment|
@@ -55,18 +59,18 @@ module RealEx
       def hash
         RealEx::Client.build_hash([RealEx::Client.timestamp, RealEx::Config.merchant_id, order_id, '', '', reference])
       end
-      
+
       def save!
         authorize!
       end
-      
+
       def update!
         self.update = true
         authorize!
       end
 
     end
-    
+
     class Card < Transaction
       attributes :card, :payer, :update, :reference, :cancel
 
@@ -79,7 +83,7 @@ module RealEx
           @request_type = 'card-new'
         end
       end
-      
+
       def to_xml
         super do |per|
           per.card do |c|
@@ -95,7 +99,7 @@ module RealEx
           end
         end
       end
-      
+
       # 20030516181127.yourmerchantid.uniqueid…smithj01.John Smith.498843******9991
       def hash
         if cancel
@@ -106,11 +110,11 @@ module RealEx
           RealEx::Client.build_hash([RealEx::Client.timestamp, RealEx::Config.merchant_id, order_id, '', '', payer.reference,card.cardholder_name,card.number])
         end
       end
-      
+
       def save!
         authorize!
       end
-      
+
       def update!
         self.update = true
         authorize!
@@ -122,15 +126,15 @@ module RealEx
       end
 
     end
-    
+
     class Authorization < Transaction
       attributes :payer, :reference, :customer_number, :variable_reference, :product_id
       attributes :billing_address, :shipping_address
-      
+
       def request_type
         'receipt-in'
       end
-      
+
       def to_xml
         super do |per|
           per.amount(amount, :currency => currency)
@@ -157,13 +161,13 @@ module RealEx
           end
         end
       end
-      
+
       # timesttimestamp.merchantid.orderid.amount.currency.payerref
       def hash
         RealEx::Client.build_hash([RealEx::Client.timestamp, RealEx::Config.merchant_id, order_id, amount, currency, payer.reference])
-      end  
+      end
     end
-    
+
     class Refund < Transaction
       attributes :payer, :reference
 
@@ -183,7 +187,7 @@ module RealEx
       def hash
         RealEx::Client.build_hash([RealEx::Client.timestamp, RealEx::Config.merchant_id, order_id, amount, currency, payer.reference])
       end
-      
+
       def refund_hash
         Digest::SHA1.hexdigest(RealEx::Config.refund_password)
       end

--- a/spec/recurring_spec.rb
+++ b/spec/recurring_spec.rb
@@ -35,20 +35,20 @@ describe "RealEx::Recurring" do
                 )
     RealEx::Client.stub!(:timestamp).and_return('20090326160218')
   end
-  
+
   it "should create tasty XML for the payer" do
     @payer.to_xml.should == "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<request type=\"payer-new\" timestamp=\"20090326160218\">\n  <merchantid>paul</merchantid>\n  <orderid></orderid>\n  <account>internet</account>\n  <payer type=\"Business\" ref=\"boom\">\n    <title>Mr.</title>\n    <firstname>Paul</firstname>\n    <surname>Campbell</surname>\n    <company>Contrast</company>\n    <address>\n      <line1>My house</line1>\n      <line1></line1>\n      <line3></line3>\n      <city>Dublin</city>\n      <county>Dublin</county>\n      <postcode>Dublin 2</postcode>\n      <country country_code=\"IE\">Ireland</country>\n    </address>\n    <phonenumbers>\n      <home>1</home>\n      <work>2</work>\n      <fax>3</fax>\n      <mobile>4</mobile>\n    </phonenumbers>\n    <email>paul@contrast.ie</email>\n  </payer>\n  <sha1hash>7e97b1b743c2599b6c1fd0c5515d369d8372df15</sha1hash>\n</request>\n"
   end
-  
+
   it "should create tasty XML for the payer update" do
     @payer.update = true
     @payer.to_xml.should == "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<request type=\"payer-edit\" timestamp=\"20090326160218\">\n  <merchantid>paul</merchantid>\n  <orderid></orderid>\n  <account>internet</account>\n  <payer type=\"Business\" ref=\"boom\">\n    <title>Mr.</title>\n    <firstname>Paul</firstname>\n    <surname>Campbell</surname>\n    <company>Contrast</company>\n    <address>\n      <line1>My house</line1>\n      <line1></line1>\n      <line3></line3>\n      <city>Dublin</city>\n      <county>Dublin</county>\n      <postcode>Dublin 2</postcode>\n      <country country_code=\"IE\">Ireland</country>\n    </address>\n    <phonenumbers>\n      <home>1</home>\n      <work>2</work>\n      <fax>3</fax>\n      <mobile>4</mobile>\n    </phonenumbers>\n    <email>paul@contrast.ie</email>\n  </payer>\n  <sha1hash>7e97b1b743c2599b6c1fd0c5515d369d8372df15</sha1hash>\n</request>\n"
   end
-  
+
   it "should create lovely XML for the card" do
     @card.to_xml.should == "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<request type=\"card-new\" timestamp=\"20090326160218\">\n  <merchantid>paul</merchantid>\n  <orderid></orderid>\n  <account>internet</account>\n  <card>\n    <ref>billabong</ref>\n    <payerref>boom</payerref>\n    <number>4111111111111111</number>\n    <expdate>0802</expdate>\n    <chname>Paul Campbell</chname>\n    <type>VISA</type>\n  </card>\n  <sha1hash>24dc62271ccaddc59082b4db45c80b0241f630f7</sha1hash>\n</request>\n"
   end
-  
+
   it "should create lovely XML for the card update" do
     @card.update = true
     @card.to_xml.should == "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<request type=\"card-update-card\" timestamp=\"20090326160218\">\n  <merchantid>paul</merchantid>\n  <orderid></orderid>\n  <account>internet</account>\n  <card>\n    <ref>billabong</ref>\n    <payerref>boom</payerref>\n    <number>4111111111111111</number>\n    <expdate>0802</expdate>\n    <chname>Paul Campbell</chname>\n    <type>VISA</type>\n  </card>\n  <sha1hash>cdcb4dd95d0d61d7c86685b1e465796ea55bdcea</sha1hash>\n</request>\n"
@@ -62,7 +62,7 @@ describe "RealEx::Recurring" do
   it "should create tasty XML for the authorization" do
     @transaction.to_xml.should == "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<request type=\"receipt-in\" timestamp=\"20090326160218\">\n  <merchantid>paul</merchantid>\n  <orderid>1234</orderid>\n  <account>internet</account>\n  <amount currency=\"EUR\">500</amount>\n  <payerref>boom</payerref>\n  <paymentmethod></paymentmethod>\n  <sha1hash>ec3afd1714b4473210c2b1eda0c6675bd13c411b</sha1hash>\n</request>\n"
   end
-  
+
   it "should create tasty XML for the refund" do
     @refund.to_xml.should == "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<request type=\"payment-out\" timestamp=\"20090326160218\">\n  <merchantid>paul</merchantid>\n  <orderid>1234</orderid>\n  <account>internet</account>\n  <amount currency=\"EUR\">500</amount>\n  <payerref>boom</payerref>\n  <paymentmethod></paymentmethod>\n  <refundhash>5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8</refundhash>\n  <sha1hash>ec3afd1714b4473210c2b1eda0c6675bd13c411b</sha1hash>\n</request>\n"
   end
@@ -85,8 +85,30 @@ describe "RealEx::Recurring without a full address" do
     @payer = RealEx::Recurring::Payer.new(:type => 'Business', :reference => 'boom', :title => 'Mr.', :firstname => 'Paul', :lastname => 'Campbell', :company => 'Contrast')
     @payer.address = RealEx::Address.new(:country => 'Ireland', :country_code => 'IE')
   end
-  
+
   it "should convert the payer" do
     @payer.to_xml.should match(/IE/)
+  end
+end
+
+describe "RealEx::Recurring without any address" do
+  before do
+    RealEx::Config.merchant_id = 'paul'
+    RealEx::Config.shared_secret = "He's not dead, he's just asleep!"
+    RealEx::Config.account = 'internet'
+
+    @card = RealEx::Card.new(
+              :number           => '4111111111111111',
+              :cvv              => '509',
+              :expiry_date      => '0802',
+              :cardholder_name  => 'Paul Campbell',
+              :type             => 'VISA',
+              :issue_number     =>  nil
+              )
+    @payer = RealEx::Recurring::Payer.new(:type => 'Business', :reference => 'boom', :title => 'Mr.', :firstname => 'Paul', :lastname => 'Campbell', :company => 'Contrast')
+  end
+
+  it "should convert the payer" do
+    @payer.to_xml.should match(/Paul/)
   end
 end


### PR DESCRIPTION
I got an error if I tried to make a transaction without supplying any address information at all.  This patch doesn't throw an error if the address is missing entirely, which is allowed by the Realex API.
